### PR TITLE
Add code coverage and badge(s)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,5 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   matrix:
@@ -17,4 +18,5 @@ script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All Notable changes to `wunderlist` will be documented in this file
+All notable changes to `wunderlist` will be documented in this file
 
 ## 1.0.0 - 201X-XX-XX
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![StyleCI](https://styleci.io/repos/65743131/shield)](https://styleci.io/repos/65743131)
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/11716c52-99b4-412b-b68c-b78e0f18f844.svg?style=flat-square)](https://insight.sensiolabs.com/projects/11716c52-99b4-412b-b68c-b78e0f18f844)
 [![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/wunderlist.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/wunderlist)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/wunderlist/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/wunderlist/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/wunderlist.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/wunderlist)
 
 This package makes it easy to create [Wunderlist tasks](https://developers.wunderlist.com/) with Laravel 5.3.


### PR DESCRIPTION
This PR brings this repository up to date with recent changes in the skeleton. The primary part of this PR is a code coverage set up and badge (https://github.com/laravel-notification-channels/skeleton/pull/6).

Also, if this repository did not have the following already, I have:
- added PHP 7.1 to .travis.yml
- fixed a typo in the changelog
